### PR TITLE
Fix 'divide by zero' possibility

### DIFF
--- a/TB_CustomControlsSwift/BWCircularSlider.swift
+++ b/TB_CustomControlsSwift/BWCircularSlider.swift
@@ -248,6 +248,9 @@ class BWCircularSlider: UIControl {
     //Sourcecode from Apple example clockControl
     //Calculate the direction in degrees from a center point to an arbitrary position.
     func AngleFromNorth(p1:CGPoint , p2:CGPoint , flipped:Bool) -> Double {
+        if(p1 == p2){
+            return 0;
+        }
         var v:CGPoint  = CGPointMake(p2.x - p1.x, p2.y - p1.y)
         let vmag:CGFloat = Square(Square(v.x) + Square(v.y))
         var result:Double = 0.0


### PR DESCRIPTION
If p1 and p2 are equal, avoid dividing by zero by returning. Solves #1 
